### PR TITLE
Improve Linux path safety

### DIFF
--- a/CatalogPlugin.cs
+++ b/CatalogPlugin.cs
@@ -230,7 +230,7 @@ namespace Metacrack
                             {
                                 var key = $"{hex1}{hex2}";
 
-                                File.AppendAllLines($"{options.OutputFolder}\\{options.Prefix}-{key}.txt", buckets[key]);
+                                File.AppendAllLines(Path.Combine(options.OutputFolder,$"{options.Prefix}-{key}.txt"), buckets[key]);
                                 buckets[key].Clear();
                             }
                         }
@@ -253,7 +253,7 @@ namespace Metacrack
 
         private static async Task DoXReference(CatalogOptions options)
         {
-            var xrefFolder = $"{options.OutputFolder}\\xref\\";
+            var xrefFolder = $"{options.OutputFolder}{Path.DirectorySeparatorChar}xref{Path.DirectorySeparatorChar}";
             if (!Directory.Exists(xrefFolder))
             {
                 WriteMessage($"Creating new xref folder at {xrefFolder}");
@@ -283,7 +283,7 @@ namespace Metacrack
                 foreach (var hex2 in Hex)
                 {
                     var key = $"{hex1}{hex2}";
-                    var path = $"{options.OutputFolder}\\{options.Prefix}-{key}.txt";
+                    var path = Path.Combine(options.OutputFolder, $"{options.Prefix}-{key}.txt");
 
                     tasks.Add(CalculateXRef(path, options));
                 }
@@ -313,8 +313,8 @@ namespace Metacrack
                 foreach (var hex2 in Hex)
                 {
                     var key = $"{hex1}{hex2}";
-                    var mapPath = $"{options.OutputFolder}\\xref\\{options.Prefix}-xref-{key}.tmp";
-                    var outputPath = $"{options.OutputFolder}\\xref\\{options.Prefix}-xref-{key}.txt";
+                    var mapPath = Path.Combine(options.OutputFolder, "xref", $"{options.Prefix}-xref-{key}.tmp");
+                    var outputPath = Path.Combine(options.OutputFolder, "xref", $"{options.Prefix}-xref-{key}.txt");
 
                     tasks.Add(OptimiseFile(mapPath, outputPath));
                 }
@@ -492,7 +492,7 @@ namespace Metacrack
             //Loop through each de, lock and write out the lines
             foreach (var de in output)
             {
-                var path = $"{options.OutputFolder}\\xref\\{options.Prefix}-xref-{de.Key}.tmp";
+                var path = Path.Combine(options.OutputFolder, "xref", "${options.Prefix}-xref-{de.Key}.tmp");
 
                 //https://blog.cdemi.io/async-waiting-inside-c-sharp-locks/           
                 try

--- a/CutPlugin.cs
+++ b/CutPlugin.cs
@@ -30,8 +30,8 @@
 
                 var fileInfo = new FileInfo(filePath);
                 var fileName = Path.GetFileNameWithoutExtension(filePath);
-                var filePathName = $"{currentDirectory}\\{fileName}";
-                var outputPath = $"{currentDirectory}\\{options.OutputPath}";
+                var filePathName = Path.Combine(currentDirectory, fileName);
+                var outputPath = Path.Combine(currentDirectory, options.OutputPath);
 
                 //Check that there are no output files
                 if (!CheckForFiles(new string[] { outputPath }))

--- a/ExportPlugin.cs
+++ b/ExportPlugin.cs
@@ -169,9 +169,9 @@ namespace Metacrack
             foreach (var hashesPath in hashFileEntries)
             {
                 var fileName = Path.GetFileNameWithoutExtension(hashesPath);
-                var plainsPath = $"{currentDirectory}\\{fileName}.plains.txt"; //email:plain
-                var foundPath = $"{currentDirectory}\\{fileName}.found.txt"; //hash:plain
-                var leftPath = $"{currentDirectory}\\{IncrementFilename(fileName, "left")}.txt"; //hash
+                var plainsPath = Path.Combine(currentDirectory, $"{fileName}.plains.txt"); //email:plain
+                var foundPath = Path.Combine(currentDirectory, $"{fileName}.found.txt"); //hash:plain
+                var leftPath = Path.Combine(currentDirectory, $"{IncrementFilename(fileName, "left")}.txt"); //hash
 
                 //Check that there are no output files
                 if (!CheckForFiles(new string[] { plainsPath, foundPath, leftPath}))
@@ -317,14 +317,14 @@ namespace Metacrack
                     if (removeHashes.Count > 0)
                     {
                         var removeHashesFileName = Path.GetFileNameWithoutExtension(options.RemoveHashesPath);
-                        var removeHashesNewPath = $"{currentDirectory}\\{IncrementFilename(removeHashesFileName, "left")}.hash"; //hash
+                        var removeHashesNewPath = Path.Combine(currentDirectory, $"{IncrementFilename(removeHashesFileName, "left")}.hash"); //hash
 
                         File.AppendAllLines(removeHashesNewPath, removeHashes);
 
                         if (removeWords.Count > 0)
                         {
                             var removeWordsFileName = Path.GetFileNameWithoutExtension(options.RemoveWordsPath);
-                            var removeWordsNewPath = $"{currentDirectory}\\{IncrementFilename(removeWordsFileName, "left")}.word"; //word
+                            var removeWordsNewPath = Path.Combine(currentDirectory, $"{IncrementFilename(removeWordsFileName, "left")}.word"); //word
 
                             File.AppendAllLines(removeWordsNewPath, removeWords);
                         }

--- a/HashPlugin.cs
+++ b/HashPlugin.cs
@@ -24,7 +24,7 @@
                 //Create a version based on the file size, so that the hash and dict are bound together
                 var fileInfo = new FileInfo(filePath);
                 var fileName = Path.GetFileNameWithoutExtension(filePath);
-                var filePathName = $"{currentDirectory}\\{fileName}";
+                var filePathName = Path.Combine(currentDirectory, fileName);
 
                 var lineCount = 0;
                 var output = new List<string>();

--- a/LookupPlugin.cs
+++ b/LookupPlugin.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -123,7 +124,7 @@ namespace Metacrack
                     //Create a version based on the file size, so that the hash and dict are bound together
                     var fileInfo = new FileInfo(filePath);
                     var fileName = Path.GetFileNameWithoutExtension(filePath);
-                    var filePathName = $"{currentDirectory}\\{fileName}";
+                    var filePathName = Path.Combine(currentDirectory, fileName);
 
                     var outputHashPath = $"{filePathName}{variation}.hash";
                     var outputWordPath = $"{filePathName}{variation}.word";
@@ -207,7 +208,7 @@ namespace Metacrack
                     foreach (var hex2 in Hex)
                     {
                         var key = $"{hex1}{hex2}";
-                        var sourcePath = $"{options.SourceFolder}\\{options.Prefix}-{key}.txt";
+                        var sourcePath = Path.Combine(options.SourceFolder, $"{options.Prefix}-{key}.txt");
                         DoLookup(key, currentDirectory, variation, sourcePath, lookups, options, rules);
 
                         bucketCount++;
@@ -360,7 +361,7 @@ namespace Metacrack
             {
                 if (lookup.Hashes.Count != lookup.Words.Count) throw new ApplicationException("Hashes count does not match wordlist count.");
 
-                var filePathName = $"{currentDirectory}\\{lookup.Filename}";
+                var filePathName = Path.Combine(currentDirectory, lookup.Filename);
 
                 if (options.Export)
                 {
@@ -452,7 +453,7 @@ namespace Metacrack
                 var key = hash[0].ToString("x2");
 
                 //Get the file name 
-                var path = $"{options.SourceFolder}\\xref\\{options.Prefix}-xref-{key}.txt";
+                var path = Path.Combine(options.SourceFolder, "xref", $"{options.Prefix}-xref-{key}.txt");
 
                 //Check if the indexes have been calculated
                 if (!_inferenceIndex.ContainsKey(key)) _inferenceIndex.Add(key, CalculateInferenceFileIndexes(key, path));

--- a/MapPlugin.cs
+++ b/MapPlugin.cs
@@ -73,7 +73,7 @@
                 //Create a version based on the file size, so that the hash and dict are bound together
                 var fileInfo = new FileInfo(filePath);
                 var fileName = Path.GetFileNameWithoutExtension(filePath);
-                var filePathName = $"{currentDirectory}\\{fileName}";
+                var filePathName = Path.Combine(currentDirectory, fileName);
 
                 _outputHashPath = $"{filePathName}.{version}.hash";
                 _outputWordPath = $"{filePathName}.{version}.word";

--- a/ParsePlugin.cs
+++ b/ParsePlugin.cs
@@ -51,7 +51,7 @@ namespace Metacrack
 
                 //Create a version based on the file size, so that the hash and dict are bound together
                 var fileName = Path.GetFileNameWithoutExtension(filePath);
-                var filePathName = $"{currentDirectory}\\{fileName}";
+                var filePathName = Path.Combine(currentDirectory, fileName);
 
                 var outputPath = $"{filePathName}.parse.txt";
                 var outputNotParsedPath = $"{filePathName}.noparse.txt";

--- a/Program.cs
+++ b/Program.cs
@@ -103,7 +103,7 @@ namespace Metacrack
         {
             // Navigate up to the solution root
             //var pluginFolder = $"{Directory.GetCurrentDirectory()}\\Plugins\\";
-            var pluginFolder = $"{AppDomain.CurrentDomain.BaseDirectory}\\Plugins\\{name}\\";
+            var pluginFolder = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Plugins", name) + Path.DirectorySeparatorChar;
 
             if (!Directory.Exists(pluginFolder))
             {

--- a/RankPlugin.cs
+++ b/RankPlugin.cs
@@ -146,7 +146,7 @@ namespace Metacrack
                     }
 
                     var fileName = Path.GetFileNameWithoutExtension(filePath);
-                    var filePathName = $"{currentDirectory}\\{fileName}";
+                    var filePathName = Path.Combine(currentDirectory, fileName);
 
                     if (lines.Count > 0)
                     {

--- a/SortPlugin.cs
+++ b/SortPlugin.cs
@@ -24,7 +24,7 @@
 
                 //Create a version based on the file size, so that the hash and dict are bound together
                 var fileName = Path.GetFileNameWithoutExtension(filePath);
-                var filePathName = $"{currentDirectory}\\{fileName}";
+                var filePathName = Path.Combine(currentDirectory, fileName);
 
                 var outputPath = $"{filePathName}.temp.txt";
 

--- a/SplitPlugin.cs
+++ b/SplitPlugin.cs
@@ -33,7 +33,7 @@
                 //Create a version based on the file size, so that the hash and dict are bound together
                 var fileInfo = new FileInfo(filePath);
                 var fileName = Path.GetFileNameWithoutExtension(filePath);
-                var filePathName = $"{currentDirectory}\\{fileName}";
+                var filePathName = Path.Combine(currentDirectory, fileName);
 
                 var lineCount = 0;
                 var part = 1;

--- a/SqlPlugin.cs
+++ b/SqlPlugin.cs
@@ -55,7 +55,7 @@ namespace Metacrack
                 WriteMessage($"Processing {sqlPath}.");
 
                 var fileName = Path.GetFileNameWithoutExtension(sqlPath);
-                var filePathName = $"{currentDirectory}\\{fileName}";
+                var filePathName = Path.Combine(currentDirectory, fileName);
                 var outputPath = $"{filePathName}.parsed.txt";
                 var metapath = $"{filePathName}.meta.txt";
                 var debugPath = $"{filePathName}.debug.txt";

--- a/ValidatePlugin.cs
+++ b/ValidatePlugin.cs
@@ -71,7 +71,7 @@ namespace Metacrack
                 //Create a version based on the file size, so that the hash and dict are bound together
                 var fileInfo = new FileInfo(filePath);
                 var fileName = Path.GetFileNameWithoutExtension(filePath);
-                var filePathName = $"{currentDirectory}\\{fileName}";
+                var filePathName = Path.Combine(currentDirectory, fileName);
 
                 _outputValidPath =  $"{filePathName}.valid{fileInfo.Extension}";
                 _outputInvalidPath = $"{filePathName}.invalid{fileInfo.Extension}";


### PR DESCRIPTION
Use OS-safe concatenation of paths using Path.Combine instead of combining manually for compatibility with non-Windows OSes